### PR TITLE
Fixed codegen namespace to align with NetDaemon

### DIFF
--- a/src/DaemonRunner/DaemonRunner/Service/RunnerService.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/RunnerService.cs
@@ -222,7 +222,7 @@ namespace NetDaemon.Service
 
             var services = await daemonHost.GetAllServices().ConfigureAwait(false);
             var sourceRx = CodeGenerator.GenerateCodeRx(
-                "Netdaemon.Generated.Reactive",
+                "NetDaemon.Generated.Reactive",
                 daemonHost.State.Select(n => n.EntityId).Distinct(),
                 services
             );


### PR DESCRIPTION
## Breaking change
Update using statements if using `GeneratedAppBase`.
`using NetDaemon.Generated.Reactive;`



## Proposed change
This PR alignes the namespace of the generated C# class to all the other Net**D**aemon namespaces (with an uppercase D).



## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

